### PR TITLE
Allow router secret injection in values and add linter

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,21 @@
+name: Linters
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  lint-helm:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run helm linter
+        run: make lint-helm

--- a/Makefile
+++ b/Makefile
@@ -140,6 +140,11 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 deploy: docker-build cluster
 	./hack/deploy_with_helm.sh
 
+.PHONY: lint-helm
+lint-helm:
+	helm lint deploy/helm/jumpstarter --set jumpstarter-controller.routerSecret=abcd
+
+
 .PHONY: undeploy
 undeploy: kustomize ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
 	$(KUSTOMIZE) build config/default | $(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -f -

--- a/deploy/helm/jumpstarter/charts/jumpstarter-controller/templates/router-secret.yaml
+++ b/deploy/helm/jumpstarter/charts/jumpstarter-controller/templates/router-secret.yaml
@@ -4,8 +4,12 @@ metadata:
   name: jumpstarter-router-secret
   namespace: {{ default .Release.Namespace .Values.namespace }}
 data:
-  {{- if .Release.IsInstall }}
+  {{- if .Values.routerSecret -}}
+  key: {{ .Values.routerSecret | b64enc }}
+  {{- else -}}
+    {{- if .Release.IsInstall }}
   key: {{ randAlphaNum 32 | b64enc }}
-  {{ else }}
+    {{ else }}
   key: {{ (lookup "v1" "Secret" (default .Release.Namespace .Values.namespace) "jumpstarter-router-secret").data.key }}
-  {{ end }}
+    {{ end }}
+  {{- end }}

--- a/deploy/helm/jumpstarter/charts/jumpstarter-controller/values.yaml
+++ b/deploy/helm/jumpstarter/charts/jumpstarter-controller/values.yaml
@@ -1,6 +1,8 @@
 
 namespace: ""
 
+routerSecret: ""
+
 grpc:
   hostname: ""
   routerHostname: ""
@@ -9,6 +11,7 @@ grpc:
   # to announce the endpoints to the clients
   endpoint: ""
   routerEndpoint: ""
+
 
   tls:
     enabled: false

--- a/deploy/helm/jumpstarter/values.kind.yaml
+++ b/deploy/helm/jumpstarter/values.kind.yaml
@@ -1,7 +1,7 @@
 global:
   baseDomain: jumpstarter.127.0.0.1.nip.io
   metrics:
-      enabled: false
+    enabled: false
 
 jumpstarter-controller:
   image: quay.io/jumpstarter-dev/jumpstarter-controller

--- a/deploy/helm/jumpstarter/values.yaml
+++ b/deploy/helm/jumpstarter/values.yaml
@@ -1,3 +1,15 @@
+## @section Global parameters
+## @descriptionStart This section contains parameters common to all the
+## components in the deployment.
+## @descriptionEnd
+##
+## @param global.baseDomain Base domain to construct the FQDN for the service endpoints.
+## @param global.namespace Namespace where the components will be deployed.
+## @param global.storageClassName Storage class name for the PVCs.
+## @param global.storageClassNameRWM Storage class name for multiple reader/writer PVCs.
+## @param global.metrics.enabled Enable metrics exporting and service
+## @param global.timestamp Timestamp to be used to trigger a new deployment, i.e. if you want pods to be restarted and pickup ":latest"
+
 global:
   baseDomain: jumpstarter.my.domain.com
   namespace: jumpstarter-lab
@@ -6,12 +18,61 @@ global:
   metrics:
       enabled: false
   timestamp: "" # can be used to timestamp deployments and make them reload
+
+## @section Jumpstarter Controller parameters
+## @descriptionStart This section contains parameters for the Jumpstarter Controller.
+## @descriptionEnd
+##
+## @param jumpstarter-controller.enabled Enable the Jumpstarter Controller.
+
+## @param jumpstarter-controller.image Image for the controller.
+## @param jumpstarter-controller.tag Tag for the controller image.
+## @param jumpstarter-controller.imagePullPolicy Image pull policy for the controller.
+
+## @param jumpstarter-controller.routerSecret Secret used to sign tokens for the router.
+##                                            If not set, a random secret will be generated.
+##                                            Please fill in to deploy from ArgoCD or the secret will be regenerated for each sync.
+## @param jumpstarter-controller.namespace Namespace where the controller will be deployed, defaults to global.namespace.
+
+## @section Ingress And Route parameters
+## @descriptionStart This section contains parameters for the Ingress and Route configurations.
+## You can enable either the gRPC ingress or the OpenShift route but not both.
+## @descriptionEnd
+##
+## @param jumpstarter-controller.grpc.hostname Hostname for the controller to use for the controller gRPC.
+## @param jumpstarter-controller.grpc.routerHostname Hostname for the controller to use for the router gRPC.
+##
+## @param jumpstarter-controller.grpc.endpoint The endpoints are passed down to the services to
+##                                           know where to announce the endpoints to the clients.
+##
+## @param jumpstarter-controller.grpc.routerEndpoint The endpoints are passed down to the services to
+##                                                 know where to announce the endpoints to the clients.
+##
+## @param jumpstarter-controller.grpc.ingress.enabled Enable the gRPC ingress configuration.
+## @param jumpstarter-controller.grpc.ingress.tls.enabled Enable TLS for the gRPC ingress.
+## @param jumpstarter-controller.grpc.ingress.tls.tlsSecret Secret containing the TLS certificate for the gRPC ingress.
+##
+## @param jumpstarter-controller.grpc.route.enabled Enable the gRPC OpenShift route configuration.
+## @param jumpstarter-controller.grpc.route.tls.enabled Enable TLS for the gRPC OpenShift route.
+
+
 jumpstarter-controller:
     enabled: true
+
+    image: quay.io/jumpstarter-dev/jumpstarter-controller
+    tag: ""
+    imagePullPolicy: IfNotPresent
+
     namespace: ""
-    hostname: ""
+    routerSecret: ""
 
     grpc:
+      hostname: ""
+      routerHostname: ""
+
+      endpoint: ""
+      routerEndpoint: ""
+
       ingress:
         enabled: false
         tls:
@@ -22,7 +83,3 @@ jumpstarter-controller:
         enabled: false
         tls:
           enabled: true
-
-    image: quay.io/jumpstarter-dev/jumpstarter-controller
-    tag: ""
-    imagePullPolicy: IfNotPresent


### PR DESCRIPTION
This commit allows router secret injection to avoid ArgoCD regeneration issues, it also enables linting for go and helm in CI