### PR TITLE
Test lease controller

### DIFF
--- a/api/v1alpha1/lease_types.go
+++ b/api/v1alpha1/lease_types.go
@@ -29,6 +29,8 @@ type LeaseSpec struct {
 	Duration metav1.Duration `json:"duration"`
 	// The selector for the exporter to be used
 	Selector metav1.LabelSelector `json:"selector"`
+	// The release flag requests the controller to end the lease now
+	Release bool `json:"release,omitempty"`
 }
 
 // LeaseStatus defines the observed state of Lease

--- a/deploy/helm/jumpstarter/charts/jumpstarter-controller/templates/crds/jumpstarter.dev_leases.yaml
+++ b/deploy/helm/jumpstarter/charts/jumpstarter-controller/templates/crds/jumpstarter.dev_leases.yaml
@@ -95,6 +95,10 @@ spec:
               duration:
                 description: The desired duration of the lease
                 type: string
+              release:
+                description: The release flag requests the controller to end the lease
+                  now
+                type: boolean
               selector:
                 description: The selector for the exporter to be used
                 properties:

--- a/internal/controller/lease_controller_test.go
+++ b/internal/controller/lease_controller_test.go
@@ -17,16 +17,312 @@ limitations under the License.
 package controller
 
 import (
+	"context"
+	"time"
+
+	jumpstarterdevv1alpha1 "github.com/jumpstarter-dev/jumpstarter-controller/api/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
+var leaseDutA2Sec = &jumpstarterdevv1alpha1.Lease{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      "lease1",
+		Namespace: "default",
+	},
+	Spec: jumpstarterdevv1alpha1.LeaseSpec{
+		Client: &corev1.ObjectReference{
+			Name:      testClient.Name,
+			Namespace: testClient.Namespace,
+		},
+		Selector: metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				"dut": "a",
+			},
+		},
+		Duration: metav1.Duration{
+			Duration: 2 * time.Second,
+		},
+	},
+}
 var _ = Describe("Lease Controller", func() {
-	Context("When reconciling a resource", func() {
+	BeforeEach(func() {
+		createExporters(context.Background(), testExporter1DutA, testExporter2DutA, testExporter3DutB)
+	})
+	AfterEach(func() {
+		ctx := context.Background()
+		deleteExporters(ctx, testExporter1DutA, testExporter2DutA, testExporter3DutB)
+		deleteLeases(ctx, "lease1", "lease2", "lease3")
+	})
 
-		It("should successfully reconcile the resource", func() {
+	When("trying to lease an available exporter", func() {
+		It("should acquire lease right away", func() {
+			lease := leaseDutA2Sec.DeepCopy()
 
-			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
-			// Example: If you expect a certain status condition after reconciliation, verify it here.
+			ctx := context.Background()
+			Expect(k8sClient.Create(ctx, lease)).To(Succeed())
+			_ = reconcileLease(ctx, lease)
+
+			updatedLease := getLease(ctx, lease.Name)
+			Expect(updatedLease.Status.Exporter).NotTo(BeNil())
+			Expect(updatedLease.Status.Exporter.Name).To(BeElementOf([]string{testExporter1DutA.Name, testExporter2DutA.Name}))
+			Expect(updatedLease.Status.BeginTime).NotTo(BeNil())
+			Expect(updatedLease.Status.EndTime).NotTo(BeNil())
+
+			updatedExporter := getExporter(ctx, updatedLease.Status.Exporter.Name)
+			Expect(updatedExporter.Status.Lease).NotTo(BeNil())
+			Expect(updatedExporter.Status.Lease.Name).To(Equal(lease.Name))
+		})
+
+		It("should be released after the lease time", func() {
+			lease := leaseDutA2Sec.DeepCopy()
+			lease.Spec.Duration.Duration = 100 * time.Millisecond
+
+			ctx := context.Background()
+			Expect(k8sClient.Create(ctx, lease)).To(Succeed())
+			_ = reconcileLease(ctx, lease)
+
+			updatedLease := getLease(ctx, lease.Name)
+			Expect(updatedLease.Status.Exporter).NotTo(BeNil())
+
+			exporterName := updatedLease.Status.Exporter.Name
+
+			time.Sleep(200 * time.Millisecond)
+			_ = reconcileLease(ctx, lease)
+
+			updatedLease = getLease(ctx, lease.Name)
+
+			// exporter is retained for record purposes
+			Expect(updatedLease.Status.Exporter).NotTo(BeNil())
+			// but the ended flag to be set
+			Expect(updatedLease.Status.Ended).To(BeTrue())
+
+			// the exporter should have no lease mark on status
+			updatedExporter := getExporter(ctx, exporterName)
+			Expect(updatedExporter.Status.Lease).To(BeNil())
+
+		})
+	})
+
+	When("trying to lease a non existing exporter", func() {
+		It("should fail right away", func() {
+			lease := leaseDutA2Sec.DeepCopy()
+			lease.Spec.Selector.MatchLabels["dut"] = "does-not-exist"
+
+			ctx := context.Background()
+			Expect(k8sClient.Create(ctx, lease)).To(Succeed())
+			_ = reconcileLease(ctx, lease)
+
+			updatedLease := getLease(ctx, lease.Name)
+			Expect(updatedLease.Status.Exporter).To(BeNil())
+
+			// TODO: add and check status conditions of the lease to indicate
+			// that no exporter exists for the given selector
+
+		})
+	})
+
+	When("trying to lease an offline exporter", func() {
+		It("should fail right away", func() {
+			// TODO: add and check an Online status condition to the exporters
+			// and a status condition to the lease to indicate failure to acquire
+			Skip("Not implemented")
+		})
+	})
+
+	When("trying to lease exporters, and some matching exporters are online and while others are offline", func() {
+		It("should acquire lease for the online exporters", func() {
+			// TODO: add and check an Online status condition to the exporters
+			Skip("Not implemented")
+		})
+	})
+
+	When("trying to lease a busy exporter", func() {
+		It("should not be acquired", func() {
+			lease := leaseDutA2Sec.DeepCopy()
+			lease.Spec.Selector.MatchLabels["dut"] = "b"
+
+			ctx := context.Background()
+			Expect(k8sClient.Create(ctx, lease)).To(Succeed())
+			_ = reconcileLease(ctx, lease)
+
+			updatedLease := getLease(ctx, lease.Name)
+			Expect(updatedLease.Status.Exporter).NotTo(BeNil())
+			Expect(updatedLease.Status.Exporter.Name).To(Equal(testExporter3DutB.Name))
+
+			updatedExporter := getExporter(ctx, updatedLease.Status.Exporter.Name)
+			Expect(updatedExporter.Status.Lease).NotTo(BeNil())
+			Expect(updatedExporter.Status.Lease.Name).To(Equal(lease.Name))
+
+			// create another lease that attempts to acquire the only dut b exporter
+			// which is already leased
+			lease2 := leaseDutA2Sec.DeepCopy()
+			lease2.Name = "lease2"
+			lease2.Spec.Selector.MatchLabels["dut"] = "b"
+			Expect(k8sClient.Create(ctx, lease2)).To(Succeed())
+			_ = reconcileLease(ctx, lease)
+
+			updatedLease = getLease(ctx, lease2.Name)
+			Expect(updatedLease.Status.Exporter).To(BeNil())
+			// TODO: add and check status conditions of the lease to indicate that the lease is waiting
+
+		})
+
+		It("should be acquired when a valid exporter lease times out", func() {
+			lease := leaseDutA2Sec.DeepCopy()
+			lease.Spec.Selector.MatchLabels["dut"] = "b"
+			lease.Spec.Duration.Duration = 500 * time.Millisecond
+
+			ctx := context.Background()
+			Expect(k8sClient.Create(ctx, lease)).To(Succeed())
+			_ = reconcileLease(ctx, lease)
+
+			updatedLease := getLease(ctx, lease.Name)
+			Expect(updatedLease.Status.Exporter).NotTo(BeNil())
+			Expect(updatedLease.Status.Exporter.Name).To(Equal(testExporter3DutB.Name))
+
+			updatedExporter := getExporter(ctx, updatedLease.Status.Exporter.Name)
+			Expect(updatedExporter.Status.Lease).NotTo(BeNil())
+			Expect(updatedExporter.Status.Lease.Name).To(Equal(lease.Name))
+
+			// create another lease that attempts to acquire the only dut b exporter
+			// which is already leased
+			lease2 := leaseDutA2Sec.DeepCopy()
+			lease2.Name = "lease2"
+			lease2.Spec.Selector.MatchLabels["dut"] = "b"
+			Expect(k8sClient.Create(ctx, lease2)).To(Succeed())
+			_ = reconcileLease(ctx, lease2)
+
+			updatedLease = getLease(ctx, lease2.Name)
+			Expect(updatedLease.Status.Exporter).To(BeNil())
+			// TODO: add and check status conditions of the lease to indicate that the lease is waiting
+
+			time.Sleep(501 * time.Millisecond)
+			_ = reconcileLease(ctx, lease)
+			_ = reconcileLease(ctx, lease2)
+			updatedLease = getLease(ctx, lease2.Name)
+			Expect(updatedLease.Status.Exporter).NotTo(BeNil())
+
+		})
+	})
+
+	When("releasing a lease early", func() {
+		It("should release the lease and exporter right away", func() {
+			lease := leaseDutA2Sec.DeepCopy()
+
+			ctx := context.Background()
+			Expect(k8sClient.Create(ctx, lease)).To(Succeed())
+			_ = reconcileLease(ctx, lease)
+
+			updatedLease := getLease(ctx, lease.Name)
+			Expect(updatedLease.Status.Exporter).NotTo(BeNil())
+
+			exporterName := updatedLease.Status.Exporter.Name
+
+			// release the lease early
+			// TODO: through the API we cannot set the status condition, we get this through the RPC,
+			// we should consider adding a flag on the spec to do this, or look at the duration too
+			updatedLease.Spec.Release = true
+
+			endTime := updatedLease.Status.EndTime
+
+			Expect(k8sClient.Update(ctx, updatedLease)).To(Succeed())
+
+			_ = reconcileLease(ctx, updatedLease)
+
+			updatedLease = getLease(ctx, lease.Name)
+			Expect(updatedLease.Status.Exporter).NotTo(BeNil())
+			Expect(updatedLease.Status.Ended).To(BeTrue())
+			Expect(updatedLease.Status.EndTime).ToNot(Equal(endTime))
+
+			updatedExporter := getExporter(ctx, exporterName)
+			Expect(updatedExporter.Status.Lease).To(BeNil())
 		})
 	})
 })
+
+var testExporter1DutA = &jumpstarterdevv1alpha1.Exporter{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      "exporter1-dut-a",
+		Namespace: "default",
+		Labels: map[string]string{
+			"dut": "a",
+		},
+	},
+}
+
+var testExporter2DutA = &jumpstarterdevv1alpha1.Exporter{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      "exporter2-dut-a",
+		Namespace: "default",
+		Labels: map[string]string{
+			"dut": "a",
+		},
+	},
+}
+
+var testExporter3DutB = &jumpstarterdevv1alpha1.Exporter{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      "exporter3-dut-b",
+		Namespace: "default",
+		Labels: map[string]string{
+			"dut": "b",
+		},
+	},
+}
+
+func reconcileLease(ctx context.Context, lease *jumpstarterdevv1alpha1.Lease) reconcile.Result {
+
+	// reconcile the exporters
+	typeNamespacedName := types.NamespacedName{
+		Name:      lease.Name,
+		Namespace: "default",
+	}
+
+	leaseReconciler := &LeaseReconciler{
+		Client: k8sClient,
+		Scheme: k8sClient.Scheme(),
+	}
+
+	res, err := leaseReconciler.Reconcile(ctx, reconcile.Request{
+		NamespacedName: typeNamespacedName,
+	})
+	Expect(err).NotTo(HaveOccurred())
+	return res
+}
+
+func getLease(ctx context.Context, name string) *jumpstarterdevv1alpha1.Lease {
+	lease := &jumpstarterdevv1alpha1.Lease{}
+	err := k8sClient.Get(ctx, types.NamespacedName{
+		Name:      name,
+		Namespace: "default",
+	}, lease)
+	Expect(err).NotTo(HaveOccurred())
+	return lease
+}
+
+func getExporter(ctx context.Context, name string) *jumpstarterdevv1alpha1.Exporter {
+	exporter := &jumpstarterdevv1alpha1.Exporter{}
+	err := k8sClient.Get(ctx, types.NamespacedName{
+		Name:      name,
+		Namespace: "default",
+	}, exporter)
+	Expect(err).NotTo(HaveOccurred())
+	return exporter
+}
+
+func deleteLeases(ctx context.Context, leases ...string) {
+	for _, lease := range leases {
+		leaseObj := &jumpstarterdevv1alpha1.Lease{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      lease,
+				Namespace: "default",
+			},
+		}
+		_ = k8sClient.Delete(ctx, leaseObj)
+	}
+}


### PR DESCRIPTION
* Adds a flag to release a lease early
* Tests the lease controller
* Fixes an existing corner case:
 if we update a lease as Ended, and then we try to update the Exporter but we fail 
(i.e. API becomes unavailable), the exporter will remain with a "Lease" in state.

This commit first attempts to remove the lease from the exporter,
double checking that the lease is ours, then updates the lease as ended.