### PR TITLE
Fix route/ingress deployment for our service-terminated tls

### DIFF
--- a/deploy/helm/jumpstarter/charts/jumpstarter-controller/templates/controller-ingress.yaml
+++ b/deploy/helm/jumpstarter/charts/jumpstarter-controller/templates/controller-ingress.yaml
@@ -1,10 +1,13 @@
-{{ if .Values.grpc.ingress.enabled }}
+{{ if eq .Values.grpc.mode "ingress" }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
+    {{ if eq .Values.grpc.tls.mode "passthrough" }}
+    nginx.ingress.kubernetes.io/ssl-passthrough: "true"
+    {{ end }}
   name: jumpstarter-controller-ingress
   namespace: {{ default .Release.Namespace .Values.namespace }}
 spec:
@@ -23,14 +26,14 @@ spec:
             name: jumpstarter-grpc
             port:
               number: 8082
-  {{ if .Values.grpc.tls.enabled }}
   tls:
-  - secretName: {{ .Values.grpc.tls.secret }}
-    hosts:
+  - hosts:
       {{ if .Values.grpc.hostname }}
       - {{ .Values.grpc.hostname }}
       {{ else }}
-      - grpc.{{ .Values.global.baseDomain | required }}
+      - grpc.{{ .Values.global.baseDomain | required "a global.baseDomain or a grpc.hostname must be provided"}}
       {{ end }}
-  {{ end }}
+    {{ if .Values.grpc.tls.controllerCertSecret }}
+    secretName: {{ .Values.grpc.tls.controllerCertSecret }}
+    {{ end }}
 {{ end }}

--- a/deploy/helm/jumpstarter/charts/jumpstarter-controller/templates/controller-route.yaml
+++ b/deploy/helm/jumpstarter/charts/jumpstarter-controller/templates/controller-route.yaml
@@ -1,7 +1,4 @@
-{{ if .Values.grpc.route.enabled }}
-  {{ if .Values.grpc.ingress.enabled }}
-    {{ required "grpc.ingress.enabled and grpc.route.enabled cannot be enabled at the same time" nil }}
-  {{ end }}
+{{ if eq .Values.grpc.mode "route" }}
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
@@ -18,10 +15,14 @@ spec:
   {{ end }}
   port:
     targetPort: 8082
-  {{ if .Values.grpc.tls.enabled }}
   tls:
-    termination: edge
-  {{ end }}
+    termination: {{ .Values.grpc.tls.mode }}
+    insecureEdgeTerminationPolicy: None
+    {{ if .Values.grpc.tls.controllerCertSecret }}
+    externalCertificate:
+      name: {{ .Values.grpc.tls.controllerCertSecret }}
+    {{ end }}
+
   to:
     kind: Service
     name: jumpstarter-grpc

--- a/deploy/helm/jumpstarter/charts/jumpstarter-controller/templates/router-ingress.yaml
+++ b/deploy/helm/jumpstarter/charts/jumpstarter-controller/templates/router-ingress.yaml
@@ -1,10 +1,13 @@
-{{ if .Values.grpc.ingress.enabled }}
+{{ if eq .Values.grpc.mode "ingress" }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
+    {{ if eq .Values.grpc.tls.mode "passthrough" }}
+    nginx.ingress.kubernetes.io/ssl-passthrough: "true"
+    {{ end }}
   name: jumpstarter-router-ingress
   namespace: {{ default .Release.Namespace .Values.namespace }}
 spec:
@@ -23,14 +26,12 @@ spec:
             name: jumpstarter-router-grpc
             port:
               number: 8083
-  {{ if .Values.grpc.tls.enabled }}
   tls:
-  - secretName: {{ .Values.grpc.tls.secret }}
+  - secretName: {{ .Values.grpc.tls.routerCertSecret }}
     hosts:
       {{ if .Values.grpc.routerHostname }}
       - {{ .Values.grpc.routerHostname }}
       {{ else }}
-      - router.{{ .Values.global.baseDomain | required }}
+      - router.{{ .Values.global.baseDomain | required "a global.baseDomain or a grpc.routerHostname must be provided" }}
       {{ end }}
-  {{ end }}
 {{ end }}

--- a/deploy/helm/jumpstarter/charts/jumpstarter-controller/templates/router-route.yaml
+++ b/deploy/helm/jumpstarter/charts/jumpstarter-controller/templates/router-route.yaml
@@ -1,7 +1,4 @@
-{{ if .Values.grpc.route.enabled }}
-  {{ if .Values.grpc.ingress.enabled }}
-    {{ required "grpc.ingress.enabled and grpc.route.enabled cannot be enabled at the same time" nil }}
-  {{ end }}
+{{ if eq .Values.grpc.mode "route" }}
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
@@ -18,10 +15,19 @@ spec:
   {{ end }}
   port:
     targetPort: 8083
-  {{ if .Values.grpc.tls.enabled }}
   tls:
-    termination: edge
-  {{ end }}
+    {{ if eq .Values.grpc.tls.mode "passthrough" }}
+    termination: passthrough
+    {{ end }}
+    {{ if eq .Values.grpc.tls.mode "reencrypt" }}
+    termination: reencrypt
+    {{ end }}
+    insecureEdgeTerminationPolicy: None
+    {{ if .Values.grpc.tls.routerCertSecret }}
+    externalCertificate:
+      name: {{ .Values.grpc.tls.routerCertSecret }}
+    {{ end }}
+
   to:
     kind: Service
     name: jumpstarter-router-grpc

--- a/deploy/helm/jumpstarter/values.kind.yaml
+++ b/deploy/helm/jumpstarter/values.kind.yaml
@@ -7,5 +7,4 @@ jumpstarter-controller:
   image: quay.io/jumpstarter-dev/jumpstarter-controller
   tag: latest
   grpc:
-    ingress:
-      enabled: true
+    mode: "ingress"

--- a/deploy/helm/jumpstarter/values.yaml
+++ b/deploy/helm/jumpstarter/values.yaml
@@ -45,8 +45,9 @@ global:
 ## @param jumpstarter-controller.grpc.hostname Hostname for the controller to use for the controller gRPC.
 ## @param jumpstarter-controller.grpc.routerHostname Hostname for the controller to use for the router gRPC.
 ##
-## @param jumpstarter-controller.grpc.tls.enabled Enable TLS for the gRPC endpoints.
-## @param jumpstarter-controller.grpc.tls.tlsSecret Secret containing the TLS certificate for the gRPC endpoints.
+## @param jumpstarter-controller.grpc.tls.mode Setup the TLS mode for endpoints, either "passthrough" or "reencrypt".
+## @param jumpstarter-controller.grpc.tls.controllerCertSecret Secret containing the TLS certificate/key for the gRPC endpoint.
+## @param jumpstarter-controller.grpc.tls.routerCertSecret Secret containing the TLS certificate/key for the gRPC router endpoints.
 ##
 ## @param jumpstarter-controller.grpc.endpoint The endpoints are passed down to the services to
 ##                                           know where to announce the endpoints to the clients.
@@ -56,7 +57,7 @@ global:
 ##
 ## @param jumpstarter-controller.grpc.ingress.enabled Enable the gRPC ingress configuration.
 ##
-## @param jumpstarter-controller.grpc.route.enabled Enable the gRPC OpenShift route configuration.
+## @param jumpstarter-controller.grpc.mode Mode to use for the gRPC endpoints, either route or ingress.
 
 
 
@@ -79,12 +80,8 @@ jumpstarter-controller:
       routerEndpoint: ""
 
       tls:
-        enabled: false
-        tlsSecret: ""
+        mode: "passthrough"
+        routerCertSecret: ""
+        controllerCertSecret: ""
 
-      ingress:
-        enabled: false
-
-      route:
-        enabled: false
-
+      mode: "route" # route or ingress


### PR DESCRIPTION
In a previous commit we started terminating TLS at the service, to help testing in kind where we rely on a nodeport for simplicity.

This commit adds passthrough/termination to the routes, and enables tls always for ingress as by default there is no support for passthrough.