### PR TITLE
Fix router/controller endpoints passed down to controller

### DIFF
--- a/deploy/helm/jumpstarter/charts/jumpstarter-controller/templates/controller-deployment.yaml
+++ b/deploy/helm/jumpstarter/charts/jumpstarter-controller/templates/controller-deployment.yaml
@@ -60,17 +60,17 @@ spec:
           {{ if .Values.grpc.endpoint }}
           value : {{ .Values.grpc.endpoint }}
           {{ else if .Values.hostname }}
-          value: {{ .Values.hostname }}:{{ if .Values.grpc.tls.enabled }}443{{ else }}80{{ end }}
+          value: {{ .Values.hostname }}:{{ .Values.grpc.tls.port }}
           {{ else }}
-          value: grpc.{{ .Values.global.baseDomain }}:{{ if .Values.grpc.tls.enabled }}443{{ else }}80{{ end }}
+          value: grpc.{{ .Values.global.baseDomain }}:{{ .Values.grpc.tls.port }}
           {{ end }}
         - name: GRPC_ROUTER_ENDPOINT
           {{ if .Values.grpc.routerEndpoint }}
           value: {{ .Values.grpc.routerEndpoint }}
           {{ else if .Values.routerHostname }}
-          value: {{ .Values.routerHostname }}:{{ if .Values.grpc.tls.enabled }}443{{ else }}80{{ end }}
+          value: {{ .Values.routerHostname }}:{{ .Values.grpc.tls.port }}
           {{ else }}
-          value: router.{{ .Values.global.baseDomain }}:{{ if .Values.grpc.tls.enabled }}443{{ else }}80{{ end }}
+          value: router.{{ .Values.global.baseDomain }}:{{ .Values.grpc.tls.port }}
           {{ end }}
         - name: CONTROLLER_KEY
           valueFrom:

--- a/deploy/helm/jumpstarter/values.yaml
+++ b/deploy/helm/jumpstarter/values.yaml
@@ -46,6 +46,7 @@ global:
 ## @param jumpstarter-controller.grpc.routerHostname Hostname for the controller to use for the router gRPC.
 ##
 ## @param jumpstarter-controller.grpc.tls.mode Setup the TLS mode for endpoints, either "passthrough" or "reencrypt".
+## @param jumpstarter-controller.grpc.tls.port Port to use for the gRPC endpoints ingress or route, this can be useful for ingress routers on non-standard ports.
 ## @param jumpstarter-controller.grpc.tls.controllerCertSecret Secret containing the TLS certificate/key for the gRPC endpoint.
 ## @param jumpstarter-controller.grpc.tls.routerCertSecret Secret containing the TLS certificate/key for the gRPC router endpoints.
 ##
@@ -81,6 +82,7 @@ jumpstarter-controller:
 
       tls:
         mode: "passthrough"
+        port: 443
         routerCertSecret: ""
         controllerCertSecret: ""
 


### PR DESCRIPTION
A helm deployment was otherwise announcing a :80 port, but we moved to all TLS because of the constraints imposed from the python grpc lib around security.