### PR TITLE
Revert "Add 0-version for latest on helm push"

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -73,4 +73,3 @@ jobs:
       - name: Push helm charts
         run: |
           helm push jumpstarter-*.tgz oci://${{ env.QUAY_ORG }}/helm
-          helm push jumpstarter-*.tgz oci://${{ env.QUAY_ORG }}/helm --version 0-latest


### PR DESCRIPTION
Reverts jumpstarter-dev/jumpstarter-controller#102

The option for push doesn't seem to exist..

https://helm.sh/docs/helm/helm_push/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Adjusted the deployment process to remove a fixed version flag during chart publishing, streamlining version management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->