### PR TITLE
Cleanup jumpstarter-secrets job 30 seconds after finishing

### DIFF
--- a/deploy/helm/jumpstarter/charts/jumpstarter-controller/templates/secrets-job.yaml
+++ b/deploy/helm/jumpstarter/charts/jumpstarter-controller/templates/secrets-job.yaml
@@ -5,9 +5,14 @@ metadata:
   labels:
     control-plane: controller-manager
     app.kubernetes.io/name: jumpstarter-controller
+  annotations:
+    # https://argo-cd.readthedocs.io/en/stable/user-guide/resource_hooks/#hook-deletion-policies
+    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
   name: jumpstarter-secrets
   namespace: {{ $namespace }}
 spec:
+  ttlSecondsAfterFinished: 30
   template:
     metadata:
       name: jumpstarter-secrets


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Adjusted the cleanup behavior so completed background tasks remain available for 30 seconds before being automatically removed, enhancing resource management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->