### PR TITLE
Bump the default nginx ingress grpc timeouts

### DIFF
--- a/deploy/helm/jumpstarter/charts/jumpstarter-controller/templates/controller-ingress.yaml
+++ b/deploy/helm/jumpstarter/charts/jumpstarter-controller/templates/controller-ingress.yaml
@@ -5,6 +5,8 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "300"
     {{ if eq .Values.grpc.tls.mode "passthrough" }}
     nginx.ingress.kubernetes.io/ssl-passthrough: "true"
     {{ end }}

--- a/deploy/helm/jumpstarter/charts/jumpstarter-controller/templates/router-ingress.yaml
+++ b/deploy/helm/jumpstarter/charts/jumpstarter-controller/templates/router-ingress.yaml
@@ -5,6 +5,8 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "300"
     {{ if eq .Values.grpc.tls.mode "passthrough" }}
     nginx.ingress.kubernetes.io/ssl-passthrough: "true"
     {{ end }}


### PR DESCRIPTION
Raise the timeouts to lower the chances of timeout disconnection for our grpc streams.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced network gateway configurations by updating timeout settings. These adjustments extend the duration for waiting on responses and sending data, which improves system reliability and performance during backend interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->