### PR TITLE
Move job to argocd Sync hook

### DIFF
--- a/deploy/helm/jumpstarter/charts/jumpstarter-controller/templates/controller-deployment.yaml
+++ b/deploy/helm/jumpstarter/charts/jumpstarter-controller/templates/controller-deployment.yaml
@@ -11,6 +11,7 @@ metadata:
     {{ end }}
   annotations:
     configmap-sha256: {{ include (print $.Template.BasePath "/cms/controller-cm.yaml") . | sha256sum }}
+    argocd.argoproj.io/sync-wave: "1"
 spec:
   selector:
     matchLabels:

--- a/deploy/helm/jumpstarter/charts/jumpstarter-controller/templates/secrets-job.yaml
+++ b/deploy/helm/jumpstarter/charts/jumpstarter-controller/templates/secrets-job.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/name: jumpstarter-controller
   annotations:
     # https://argo-cd.readthedocs.io/en/stable/user-guide/resource_hooks/#hook-deletion-policies
-    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook: Sync
     argocd.argoproj.io/hook-delete-policy: HookSucceeded
   name: jumpstarter-secrets
   namespace: {{ $namespace }}


### PR DESCRIPTION
Previously we put the job in the post sync hook, argocd is waiting for the deployments to be ready before running the postsync hooks (that is, creating the job) the deployments are waiting for the postsync hooks (the job) to create the secret, essentially a deadlock situation

Now that the job in the the sync hook, argocd has nothing to wait for, it can create the job right away.

Also previously, the deployment would error out at first, since the secret does not exist yet, end eventually make progress after its creation.

Now: we order it a "wave" later, so the deployment won't be created by argocd until the job has finished

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Adjusted the timing of a deployment task so that it now executes during system synchronization rather than afterward, ensuring a more seamless and integrated update process.
  - Added a new synchronization wave parameter to the deployment configuration for improved control over deployment behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->