### PR TITLE
Testing/Linting release-* stable branches

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches:
       - main
-
+      - 'release-*'
 jobs:
   e2e-tests:
     strategy:
@@ -17,7 +17,8 @@ jobs:
       - uses: jumpstarter-dev/jumpstarter-e2e@main
         with:
           controller-ref: ${{ github.ref }}
-          jumpstarter-ref: main
+          # use the matching branch on the jumpstarter repo
+          jumpstarter-ref: ${{ github.event.pull_request.base.ref }}
   e2e-tests-28d6b1cc3b49ab9ae176918ab9709a2e2522c97e:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - main
+      - 'release-*'
   pull_request:
     branches:
       - main
+      - 'release-*'
 
 jobs:
   lint-helm:

--- a/.github/workflows/pr-kind.yaml
+++ b/.github/workflows/pr-kind.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - 'release-*'
 
 jobs:
   deploy-kind:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - 'release-*'
 
 jobs:
   tests:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated end-to-end test workflow to run on pull requests targeting branches matching `release-*` as well as `main`.
  - Workflow now dynamically uses the base branch of the pull request for testing, ensuring better alignment with targeted branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->