### PR TITLE
Provision client object if it does not exist

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -151,7 +151,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	authenticator, prefix, option, err := config.LoadConfiguration(
+	authenticator, prefix, option, provisioning, err := config.LoadConfiguration(
 		context.Background(),
 		mgr.GetAPIReader(),
 		mgr.GetScheme(),
@@ -205,7 +205,7 @@ func main() {
 		Client: watchClient,
 		Scheme: mgr.GetScheme(),
 		Authn:  authentication.NewBearerTokenAuthenticator(authenticator),
-		Authz:  authorization.NewBasicAuthorizer(watchClient, prefix),
+		Authz:  authorization.NewBasicAuthorizer(watchClient, prefix, provisioning.Enabled),
 		Attr: authorization.NewMetadataAttributesGetter(authorization.MetadataAttributesGetterConfig{
 			NamespaceKey: "jumpstarter-namespace",
 			ResourceKey:  "jumpstarter-kind",

--- a/internal/authorization/metadata_test.go
+++ b/internal/authorization/metadata_test.go
@@ -1,0 +1,47 @@
+package authorization
+
+import (
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
+func TestNormalizeName(t *testing.T) {
+	testcases := []struct {
+		input  string
+		output string
+	}{
+		{
+			input:  "foo",
+			output: "oidc-foo-2c26b4",
+		},
+		{
+			input:  "foo@example.com",
+			output: "oidc-foo-example-com-321ba1",
+		},
+		{
+			input:  "foo@@@@@example.com",
+			output: "oidc-foo-example-com-5ac340",
+		},
+		{
+			input:  "@foo@example.com@",
+			output: "oidc-foo-example-com-5be6ea",
+		},
+		{
+			input:  strings.Repeat("foo", 30),
+			output: "oidc-foofoofoofoofoofoofoofoofoofoofoofoof-4ac4a7",
+		},
+	}
+	for _, testcase := range testcases {
+		result := normalizeName(testcase.input)
+		if validation.IsDNS1123Subdomain(result) != nil {
+			t.Errorf("normalizing the name %s does not produce a valid RFC1123 subdomain, but %s",
+				testcase.input, result)
+		}
+		if result != testcase.output {
+			t.Errorf("normalizing the name %s does not produce the expected output %s, but %s",
+				testcase.input, testcase.output, result)
+		}
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,10 +22,10 @@ func LoadConfiguration(
 	key client.ObjectKey,
 	signer *oidc.Signer,
 	certificateAuthority string,
-) (authenticator.Token, string, grpc.ServerOption, error) {
+) (authenticator.Token, string, grpc.ServerOption, *Provisioning, error) {
 	var configmap corev1.ConfigMap
 	if err := client.Get(ctx, key, &configmap); err != nil {
-		return nil, "", nil, err
+		return nil, "", nil, nil, err
 	}
 
 	rawAuthenticationConfiguration, ok := configmap.Data["authentication"]
@@ -40,24 +40,24 @@ func LoadConfiguration(
 			certificateAuthority,
 		)
 		if err != nil {
-			return nil, "", nil, err
+			return nil, "", nil, nil, err
 		}
 
 		return authenticator, prefix, grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
 			MinTime:             1 * time.Second,
 			PermitWithoutStream: true,
-		}), nil
+		}), &Provisioning{Enabled: false}, nil
 	}
 
 	rawConfig, ok := configmap.Data["config"]
 	if !ok {
-		return nil, "", nil, fmt.Errorf("LoadConfiguration: missing config section")
+		return nil, "", nil, nil, fmt.Errorf("LoadConfiguration: missing config section")
 	}
 
 	var config Config
 	err := yaml.UnmarshalStrict([]byte(rawConfig), &config)
 	if err != nil {
-		return nil, "", nil, err
+		return nil, "", nil, nil, err
 	}
 
 	authenticator, prefix, err := LoadAuthenticationConfiguration(
@@ -68,13 +68,13 @@ func LoadConfiguration(
 		certificateAuthority,
 	)
 	if err != nil {
-		return nil, "", nil, err
+		return nil, "", nil, nil, err
 	}
 
 	serverOptions, err := LoadGrpcConfiguration(config.Grpc)
 	if err != nil {
-		return nil, "", nil, err
+		return nil, "", nil, nil, err
 	}
 
-	return authenticator, prefix, serverOptions, nil
+	return authenticator, prefix, serverOptions, &config.Provisioning, nil
 }

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -6,12 +6,17 @@ import (
 
 type Config struct {
 	Authentication Authentication `json:"authentication"`
+	Provisioning   Provisioning   `json:"provisioning"`
 	Grpc           Grpc           `json:"grpc"`
 }
 
 type Authentication struct {
 	Internal Internal                            `json:"internal"`
 	JWT      []apiserverv1beta1.JWTAuthenticator `json:"jwt"`
+}
+
+type Provisioning struct {
+	Enabled bool `json:"enabled"`
 }
 
 type Internal struct {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - When a client resource is not found during authorization, it is now automatically created using the requesting user's name.
  - If a resource name is missing in metadata, a sanitized and hashed version of the user's name is used as a fallback to ensure uniqueness.
  - Added a provisioning mode toggle to control automatic client creation during authorization.

- **Bug Fixes**
  - Improved error handling during client resource authorization to provide clearer authorization outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->