### PR TITLE
Fixup validation of oidc configuration

### DIFF
--- a/deploy/helm/jumpstarter/charts/jumpstarter-controller/model.py
+++ b/deploy/helm/jumpstarter/charts/jumpstarter-controller/model.py
@@ -95,14 +95,11 @@ class PrefixedClaimOrExpression1(BaseModel):
 
     claim: str
     prefix: str
-    expression: Optional[str] = None
 
 
 class PrefixedClaimOrExpression2(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    claim: Optional[str] = None
-    prefix: str
     expression: str
 
 

--- a/deploy/helm/jumpstarter/charts/jumpstarter-controller/values.schema.json
+++ b/deploy/helm/jumpstarter/charts/jumpstarter-controller/values.schema.json
@@ -763,18 +763,6 @@
         "prefix": {
           "title": "Prefix",
           "type": "string"
-        },
-        "expression": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Expression"
         }
       },
       "required": [
@@ -787,29 +775,12 @@
     "PrefixedClaimOrExpression2": {
       "additionalProperties": false,
       "properties": {
-        "claim": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Claim"
-        },
-        "prefix": {
-          "title": "Prefix",
-          "type": "string"
-        },
         "expression": {
           "title": "Expression",
           "type": "string"
         }
       },
       "required": [
-        "prefix",
         "expression"
       ],
       "title": "PrefixedClaimOrExpression2",


### PR DESCRIPTION
Context:

This was previously allowed, and worked:

claimMappings:
username:
expression: '"kubernetes:" + claims["[kubernetes.io](http://kubernetes.io/)"]["namespace"]'

But not allowed anymore by our schema validation in helm. This change enables this again.

Fixes-Issue: #158 

(by letting the admin configure the right settings)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Simplified configuration schema for claim/expression selectors into two mutually exclusive shapes: either claim+prefix or expression.
- Chores
  - Tightened validation rules to enforce the two-shape union, removing previously mixed/optional fields. Configs combining claim/prefix with expression will no longer be accepted.
- Documentation
  - Clarified accepted configuration shapes to guide updates: use either {claim, prefix} or {expression} exclusively.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->