### PR TITLE
Fix crd generation to put files in the right directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,13 +49,13 @@ help: ## Display this help.
 
 .PHONY: manifests
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
-	$(CONTROLLER_GEN) 	rbac:roleName=jumpstarter-manager-role crd webhook paths="./..." \
-						output:crd:artifacts:config=deploy/helm/jumpstarter/charts/jumpstarter-controller/templates/crds/ \
+	$(CONTROLLER_GEN) 	rbac:roleName=jumpstarter-manager-role crd webhook paths="./api/..." paths="./internal/..." \
+						output:crd:artifacts:config=deploy/helm/jumpstarter/crds/ \
 						output:rbac:artifacts:config=deploy/helm/jumpstarter/charts/jumpstarter-controller/templates/rbac/
 
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
-	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
+	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./api/..." paths="./internal/..."
 
 .PHONY: fmt
 fmt: ## Run go fmt against code.

--- a/deploy/helm/jumpstarter/crds/jumpstarter.dev_leases.yaml
+++ b/deploy/helm/jumpstarter/crds/jumpstarter.dev_leases.yaml
@@ -49,6 +49,12 @@ spec:
           spec:
             description: LeaseSpec defines the desired state of Lease
             properties:
+              beginTime:
+                description: |-
+                  Requested start time. If omitted, lease starts when exporter is acquired.
+                  Immutable after lease starts (cannot change the past).
+                format: date-time
+                type: string
               clientRef:
                 description: The client that is requesting the lease
                 properties:
@@ -64,7 +70,16 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               duration:
-                description: The desired duration of the lease
+                description: |-
+                  Duration of the lease. Must be positive when provided.
+                  Can be omitted (nil) when both BeginTime and EndTime are provided,
+                  in which case it's calculated as EndTime - BeginTime.
+                type: string
+              endTime:
+                description: |-
+                  Requested end time. If specified with BeginTime, Duration is calculated.
+                  Can be updated to extend or shorten active leases.
+                format: date-time
                 type: string
               release:
                 description: The release flag requests the controller to end the lease
@@ -118,7 +133,6 @@ spec:
                 x-kubernetes-map-type: atomic
             required:
             - clientRef
-            - duration
             - selector
             type: object
           status:
@@ -127,7 +141,7 @@ spec:
               beginTime:
                 description: |-
                   If the lease has been acquired an exporter name is assigned
-                  and then and then it can be used, it will be empty while still pending
+                  and then it can be used, it will be empty while still pending
                 format: date-time
                 type: string
               conditions:

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -63,7 +63,7 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "deploy", "helm", "jumpstarter", "charts", "jumpstarter-controller", "templates", "crds")},
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "deploy", "helm", "jumpstarter", "crds")},
 		ErrorIfCRDPathMissing: true,
 
 		// The BinaryAssetsDirectory is only required if you want to run the tests directly


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Lease resources now support beginTime and endTime, enabling explicit scheduling windows.
  * Duration becomes optional and, when omitted, is derived from endTime − beginTime. Must be positive if provided.
  * endTime can be updated to extend or shorten active leases.

* **Documentation**
  * Clarified field descriptions for Lease spec and status, improving guidance and removing redundant wording.

* **Chores**
  * Updated generation and test configurations to use consolidated CRD locations and narrower code paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->