### PR TITLE
Update nginx wait for operator-e2e

### DIFF
--- a/hack/utils
+++ b/hack/utils
@@ -73,13 +73,9 @@ install_nginx_ingress() {
 
   echo -e "${GREEN}Waiting for nginx to be ready ...${NC}"
 
-  while ! kubectl get pods --namespace ingress-nginx --selector=app.kubernetes.io/component=controller > /dev/null 2>&1; do
-    sleep 1
-  done
 
   kubectl wait --namespace ingress-nginx \
-    --for=condition=ready pod \
-    --selector=app.kubernetes.io/component=controller \
+    --for=condition=available deployment/ingress-nginx-controller \
     --timeout=180s
 
   echo -e "${GREEN}Nginx ingress installed successfully${NC}"


### PR DESCRIPTION
The nginx ingress can be slow to deploy, and makes the operator e2e test fail sometimes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched readiness checks from individual pod polling to waiting for the controller deployment to become available.
  * Increased deployment readiness timeout from 90s to 180s to improve reliability during infrastructure operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->