### PR TITLE
nginx: don't wait for deployment ready, it needs a minute

### DIFF
--- a/hack/utils
+++ b/hack/utils
@@ -77,11 +77,6 @@ install_nginx_ingress() {
     sleep 1
   done
 
-  kubectl wait --namespace ingress-nginx \
-    --for=condition=ready pod \
-    --selector=app.kubernetes.io/component=controller \
-    --timeout=90s
-
   echo -e "${GREEN}Nginx ingress installed successfully${NC}"
 }
 


### PR DESCRIPTION
It will happen in the background, and we avoid some failures that happen on the kubectl wait

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified ingress controller initialization and readiness verification during system startup. Changes to the verification mechanism may affect overall startup duration and failure detection timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->