### PR TITLE
Support portable authentication tokens with backward compatibility

### DIFF
--- a/api/v1alpha1/client_helpers.go
+++ b/api/v1alpha1/client_helpers.go
@@ -3,11 +3,14 @@ package v1alpha1
 import "strings"
 
 func (c *Client) InternalSubject() string {
-	return strings.Join([]string{"client", c.Namespace, c.Name, string(c.UID)}, ":")
+	return strings.Join([]string{"client", c.Name}, ":")
 }
 
 func (c *Client) Usernames(prefix string) []string {
-	usernames := []string{prefix + c.InternalSubject()}
+	usernames := []string{
+		prefix + strings.Join([]string{"client", c.Name}, ":"),                             // New portable format
+		prefix + strings.Join([]string{"client", c.Namespace, c.Name, string(c.UID)}, ":"), // Legacy format
+	}
 
 	if c.Spec.Username != nil {
 		usernames = append(usernames, *c.Spec.Username)

--- a/api/v1alpha1/exporter_helpers.go
+++ b/api/v1alpha1/exporter_helpers.go
@@ -10,11 +10,14 @@ import (
 )
 
 func (e *Exporter) InternalSubject() string {
-	return strings.Join([]string{"exporter", e.Namespace, e.Name, string(e.UID)}, ":")
+	return strings.Join([]string{"exporter", e.Name}, ":")
 }
 
 func (e *Exporter) Usernames(prefix string) []string {
-	usernames := []string{prefix + e.InternalSubject()}
+	usernames := []string{
+		prefix + strings.Join([]string{"exporter", e.Name}, ":"),                             // New portable format
+		prefix + strings.Join([]string{"exporter", e.Namespace, e.Name, string(e.UID)}, ":"), // Legacy format
+	}
 
 	if e.Spec.Username != nil {
 		usernames = append(usernames, *e.Spec.Username)


### PR DESCRIPTION
Enable Client/Exporter migration across clusters by using name-only authentication tokens. Usernames() now returns both portable format (new) and namespace/UUID format (legacy) to maintain compatibility with existing tokens.

This allows copying objects and their token secrets between clusters without token regeneration or without setting a migrated-uid annotation.

This will only work for newly generated tokens, but does not work to migrate existing tokens.

Related-Issue: jumpstarter-dev/jumpstarter#25 188

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated client identifier formatting to support both portable and legacy formats while maintaining backward compatibility.
  * Simplified exporter identifier format with dual-format support for portable and legacy identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->