### PR TITLE
Add project badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# jumpstarter-router
+# jumpstarter-controller
 
 [![Build and push container image](https://github.com/jumpstarter-dev/jumpstarter-controller/actions/workflows/build.yaml/badge.svg)](https://github.com/jumpstarter-dev/jumpstarter-controller/actions/workflows/build.yaml)
 ![GitHub Release](https://img.shields.io/github/v/release/jumpstarter-dev/jumpstarter-controller)


### PR DESCRIPTION
Added badges for build status, release, downloads, and DeepWiki (for auto-update).

For DeepWiki to update automatically, you just need to add the badge to the README.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Project title updated to a new name.
  * Added four status badges (build/push image, release, downloads, docs).
  * Inserted a top-level TODO beneath the title.
  * Replaced the existing Description content with a TODO placeholder requesting an in-depth overview.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->