### PR TITLE
force secrets-job to run first

### DIFF
--- a/deploy/helm/jumpstarter/charts/jumpstarter-controller/templates/rbac/role.yaml
+++ b/deploy/helm/jumpstarter/charts/jumpstarter-controller/templates/rbac/role.yaml
@@ -3,6 +3,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: jumpstarter-manager-role
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
 rules:
 - apiGroups:
   - ""

--- a/deploy/helm/jumpstarter/charts/jumpstarter-controller/templates/rbac/role_binding.yaml
+++ b/deploy/helm/jumpstarter/charts/jumpstarter-controller/templates/rbac/role_binding.yaml
@@ -3,8 +3,9 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/name: jumpstarter-router
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
   name: jumpstarter-manager-rolebinding
-  
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/deploy/helm/jumpstarter/charts/jumpstarter-controller/templates/rbac/service_account.yaml
+++ b/deploy/helm/jumpstarter/charts/jumpstarter-controller/templates/rbac/service_account.yaml
@@ -3,5 +3,7 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/name: jumpstarter-router
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
   name: controller-manager
   namespace: {{ default .Release.Namespace .Values.namespace }}

--- a/deploy/helm/jumpstarter/charts/jumpstarter-controller/templates/secrets-job.yaml
+++ b/deploy/helm/jumpstarter/charts/jumpstarter-controller/templates/secrets-job.yaml
@@ -9,6 +9,7 @@ metadata:
     # https://argo-cd.readthedocs.io/en/stable/user-guide/resource_hooks/#hook-deletion-policies
     argocd.argoproj.io/hook: Sync
     argocd.argoproj.io/hook-delete-policy: HookSucceeded
+    argocd.argoproj.io/sync-wave: "-1"
   name: jumpstarter-secrets
   namespace: {{ $namespace }}
 spec:


### PR DESCRIPTION
Added annotations to help GitOps/ArgoCD deploy resources in the correct order.

The deployment of the operator stalls because secrets
- jumpstarter-controller-secret
- jumpstarter-router-secret
are not being created prior to other resources depending on them. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration for controller components to establish proper synchronization ordering during rollout.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->