### PR TITLE
Support direct exporter leasing by name in addition to the existing l…

### DIFF
--- a/api/v1alpha1/lease_types.go
+++ b/api/v1alpha1/lease_types.go
@@ -29,8 +29,11 @@ type LeaseSpec struct {
 	// Can be omitted (nil) when both BeginTime and EndTime are provided,
 	// in which case it's calculated as EndTime - BeginTime.
 	Duration *metav1.Duration `json:"duration,omitempty"`
-	// The selector for the exporter to be used
-	Selector metav1.LabelSelector `json:"selector"`
+	// The selector for the exporter to be used (mutually exclusive with DeviceName)
+	Selector metav1.LabelSelector `json:"selector,omitempty"`
+	// Direct device selection by name (mutually exclusive with Selector)
+	// When specified, the lease will only match this specific exporter
+	DeviceName *string `json:"deviceName,omitempty"`
 	// The release flag requests the controller to end the lease now
 	Release bool `json:"release,omitempty"`
 	// Requested start time. If omitted, lease starts when exporter is acquired.


### PR DESCRIPTION
Add support for leasing an exporter by name in addition to label-based selection.
The controller now handles the new exporter_selection, validates that exactly one option is provided and its not empty, and routes leases through either the direct name-based path or the existing selector-based flow. 
Existing behavior is unchanged.

Issue: https://github.com/jumpstarter-dev/jumpstarter/issues/638
Releted to: https://github.com/jumpstarter-dev/jumpstarter-protocol/pull/34 

TODO:
- Add tests coverage
- Implement CLI changes once the protocol + controller side flows are approved.